### PR TITLE
Add date selection in timeline view

### DIFF
--- a/app/src/main/java/com/example/symptomtracker/ui/components/DateTimeInput.kt
+++ b/app/src/main/java/com/example/symptomtracker/ui/components/DateTimeInput.kt
@@ -10,11 +10,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -207,7 +213,38 @@ fun DateTimeInputRow(
     }
 }
 
-@Preview
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerModal(
+    onDismissRequest: () -> Unit,
+    onDateSelected: (Long) -> Unit,
+    initialDate: OffsetDateTime,
+) {
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = initialDate.toInstant().toEpochMilli(),
+        selectableDates = object : SelectableDates {
+            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                return utcTimeMillis <= System.currentTimeMillis()
+            }
+        }
+    )
+
+    DatePickerDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            Button(onClick = {
+                datePickerState.selectedDateMillis?.let(onDateSelected)
+                onDismissRequest()
+            }) {
+                Text(text = "OK")
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+
+@Preview(showBackground = true)
 @Composable
 fun Preview() {
     SymptomTrackerTheme {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="date_label">Date</string>
     <string name="edit_date_cd">Edit date</string>
     <string name="no_logs_found">No logs found</string>
-    <string name="timeline_title">Today\'s timeline</string>
+    <string name="timeline_title">Timeline</string>
     <string name="datetime_format_hh_mm_ss">HH:mm:ss</string>
+    <string name="previous_day_cd">Go to previous day</string>
+    <string name="next_day_cd">Go to next day</string>
 </resources>


### PR DESCRIPTION
This commit improves the timeline view on the homepage by introducing three methods for the user to change the date displayed in the timeline:
- Arrows on either side of the displayed date enable navigation backward and forward one day at a time. The forward arrow is hidden when viewing the current day.
- Users can swipe on the timeline view to navigate between dates. Swiping forward from the current day does nothing.
- Clicking on the current date opens a date picker modal, allowing users to select a different date.