### PR TITLE
Update Home FAB to a Button Menu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.9.2'
-    implementation "androidx.compose.material3:material3:1.4.0"
+    implementation "androidx.compose.material3:material3:1.5.0-alpha04"
     implementation "androidx.compose.material3:material3-window-size-class:1.4.0"
     implementation "androidx.navigation:navigation-compose:2.9.3"
 

--- a/app/src/main/java/com/example/symptomtracker/feature/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/example/symptomtracker/feature/home/HomeScreenViewModel.kt
@@ -49,16 +49,16 @@ class HomeScreenViewModel @Inject constructor(
 
     fun handleEvent(event: HomeScreenEvent) {
         when (event) {
-            is HomeScreenEvent.UpdateBottomSheetVisibility -> updateBottomSheetVisibility(visible = event.visible)
+            is HomeScreenEvent.UpdateQuickAddMenuVisibility -> updateQuickAddMenuVisibility(visible = event.visible)
             is HomeScreenEvent.GoToPreviousDay -> goToPreviousDay()
             is HomeScreenEvent.GoToNextDay -> goToNextDay()
             is HomeScreenEvent.UpdateDate -> updateDate(date = event.date)
         }
     }
 
-    private fun updateBottomSheetVisibility(visible: Boolean) {
+    private fun updateQuickAddMenuVisibility(visible: Boolean) {
         uiState = uiState.copy(
-            showBottomSheet = visible
+            showQuickAddMenu = visible
         )
     }
 
@@ -107,14 +107,14 @@ class HomeScreenViewModel @Inject constructor(
 }
 
 data class UiState(
-    val showBottomSheet: Boolean = false,
+    val showQuickAddMenu: Boolean = false,
     val logs: List<Log> = listOf(),
     val isToday: Boolean = true,
     val date: LocalDate,
 )
 
 sealed interface HomeScreenEvent {
-    data class UpdateBottomSheetVisibility(val visible: Boolean) : HomeScreenEvent
+    data class UpdateQuickAddMenuVisibility(val visible: Boolean) : HomeScreenEvent
     data object GoToPreviousDay : HomeScreenEvent
     data object GoToNextDay : HomeScreenEvent
     data class UpdateDate(val date: LocalDate) : HomeScreenEvent

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="validation_invalid">Invalid</string>
 
     <string name="mealie_import_title">Log food from Mealie recipe</string>
+    <string name="mealie_import_action">Mealie import</string>
     <string name="mealie_import_results_header">Ingredients to import</string>
     <string name="mealie_import_url_label">Recipe URL:</string>
     <string name="mealie_import_error_no_ingredients">No ingredients found.</string>

--- a/app/src/test/java/com/example/symptomtracker/feature/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/example/symptomtracker/feature/home/HomeScreenViewModelTest.kt
@@ -57,7 +57,7 @@ class HomeScreenViewModelTest {
         symptomRepository.sendSymptomLogs(symptomLogs)
         movementRepository.sendMovementLogs(movementLogs)
 
-        assertFalse(viewModel.uiState.showBottomSheet)
+        assertFalse(viewModel.uiState.showQuickAddMenu)
         assertEquals(listOf(foodLogs[1], symptomLogs[0]), viewModel.uiState.logs)
         assertTrue(viewModel.uiState.isToday)
 
@@ -65,14 +65,14 @@ class HomeScreenViewModelTest {
     }
 
     @Test
-    fun bottomSheetVisibilityUpdates_whenUpdateBottomSheetVisibilityIsCalled() = runTest {
+    fun quickAddMenuVisibilityUpdates_whenUpdateQuickAddMenuVisibilityIsCalled() = runTest {
         val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.uiState }
 
-        assertFalse(viewModel.uiState.showBottomSheet)
+        assertFalse(viewModel.uiState.showQuickAddMenu)
 
-        viewModel.handleEvent(HomeScreenEvent.UpdateBottomSheetVisibility(visible = true))
+        viewModel.handleEvent(HomeScreenEvent.UpdateQuickAddMenuVisibility(visible = true))
 
-        assertTrue(viewModel.uiState.showBottomSheet)
+        assertTrue(viewModel.uiState.showQuickAddMenu)
 
         collectJob.cancel()
     }


### PR DESCRIPTION
The bottom sheet containing the 'quick add' functionality on the home screen is a little clunky.

This addresses that by updating Material 3 to get access to the `FloatingActionsButtonMenu` in the Expressive API.

The button menu provides a much cleaner interface for the 'quick add' options.